### PR TITLE
Subsystem test

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/ClusterConnectionControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ClusterConnectionControlHandler.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.messaging.CommonAttributes.NODE_ID;
+import static org.jboss.as.messaging.CommonAttributes.TOPOLOGY;
+
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
@@ -47,9 +50,6 @@ import org.jboss.dmr.ModelType;
 public class ClusterConnectionControlHandler extends AbstractHornetQComponentControlHandler<ClusterConnectionControl> {
 
     public static final ClusterConnectionControlHandler INSTANCE = new ClusterConnectionControlHandler();
-
-    public static final String NODE_ID = "node-id";
-    public static final String TOPOLOGY = "topology";
 
     // we keep the operation for backwards compatibility but it duplicates the "static-connectors" writable attribute
     @Deprecated

--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -696,6 +696,7 @@ public interface CommonAttributes {
     String SUBSYSTEM ="subsystem";
     String TEMPORARY ="temporary";
     String TOPIC_ADDRESS ="topic-address";
+    String TOPOLOGY = "topology";
     String TRANSACTION = "transaction";
     String TYPE_ATTR_NAME ="type";
     String VERSION = "version";

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingDescriptions.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingDescriptions.java
@@ -93,6 +93,7 @@ import static org.jboss.as.messaging.CommonAttributes.STARTED;
 import static org.jboss.as.messaging.CommonAttributes.SUBSCRIPTION_COUNT;
 import static org.jboss.as.messaging.CommonAttributes.TEMPORARY;
 import static org.jboss.as.messaging.CommonAttributes.TOPIC_ADDRESS;
+import static org.jboss.as.messaging.CommonAttributes.TOPOLOGY;
 
 import java.util.List;
 import java.util.Locale;
@@ -1035,6 +1036,7 @@ public class MessagingDescriptions {
 
         final ModelNode attrs = root.get(ATTRIBUTES);
         addResourceAttributeDescription(bundle, CLUSTER_CONNECTION, attrs, NODE_ID, ModelType.STRING, false, null);
+        addResourceAttributeDescription(bundle, CLUSTER_CONNECTION, attrs, TOPOLOGY, ModelType.STRING, false, null);
         addResourceAttributeDescription(bundle, CLUSTER_CONNECTION, attrs, STARTED, ModelType.BOOLEAN, false, null);
 
         root.get(OPERATIONS); // placeholder
@@ -1222,6 +1224,8 @@ public class MessagingDescriptions {
             attr.addResourceAttributeDescription(bundle, null, root);
         }
 
+        addResourceAttributeDescription(bundle, "acceptor", root.get(ATTRIBUTES), STARTED, ModelType.BOOLEAN, false, null);
+
         getParamChildrenDescription(bundle, root, "acceptor");
 
         return root;
@@ -1251,6 +1255,8 @@ public class MessagingDescriptions {
         for (AttributeDefinition attr : TransportConfigOperationHandlers.IN_VM) {
             attr.addResourceAttributeDescription(bundle, null, root);
         }
+
+        addResourceAttributeDescription(bundle, "acceptor", root.get(ATTRIBUTES), STARTED, ModelType.BOOLEAN, false, null);
 
         getParamChildrenDescription(bundle, root, "acceptor");
 

--- a/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
+++ b/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
@@ -362,6 +362,7 @@ cluster-connection.retry-interval=The period in milliseconds between subsequent 
 cluster-connection.retry-interval-multiplier=A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.
 cluster-connection.confirmation-window-size=The confirmation-window-size to use for the connection used to forward messages to a target node.
 cluster-connection.static-connectors=The statically defined list of connectors to which this cluster connection will make connections. Must be undefined (null) if 'discovery-group-name' is defined.
+cluster-connection.topology=The topology of the nodes that this cluster connection is aware of.
 cluster-connection.allow-direct-connections-only=Whether, if a node learns of the existence of a node that is more than 1 hop away, we do not create a bridge for direct cluster connection. Only relevant if 'static-connectors' is defined.
 cluster-connection.discovery-group-name=The discovery group used to obtain the list of other servers in the cluster to which this cluster connection will make connections. Must be undefined (null) if 'static-connectors' is defined.
 cluster-connection.node-id=The node ID used by this cluster connection.


### PR DESCRIPTION
I fixed the failures I had in the messaging subsystem (started attribute for acceptor + topology on cluster-connection).

However, I did not see all the warnings there was in the logs you sent earlier. Is it normal?
